### PR TITLE
Modified three files to fix the bibliography section.

### DIFF
--- a/book/bibliography.md
+++ b/book/bibliography.md
@@ -10,3 +10,6 @@ This page will contain a full bibliography of resource referenced across the boo
 - {cite:p}`Kim2023`
 - {cite:p}`NIST2022`
 - {cite:p}`Wilkinson2016`
+
+```{bibliography}
+```

--- a/book/references.bib
+++ b/book/references.bib
@@ -42,28 +42,19 @@
 	volume = {1},
 	number = {8},
 	pages = {e217},
-	keywords = {cheminformatics, chemical structure search, drug discovery, molecular similarity, PubChem, public database},
-	doi = {https://doi.org/10.1002/cpz1.217},
-	url = {https://currentprotocols.onlinelibrary.wiley.com/doi/abs/10.1002/cpz1.217},
-	eprint = {https://currentprotocols.onlinelibrary.wiley.com/doi/pdf/10.1002/cpz1.217},
-	abstract = {Abstract PubChem (https://pubchem.ncbi.nlm.nih.gov) is a public chemical database that serves scientific communities as well as the general public. This database collects chemical information from hundreds of data sources and organizes them into multiple data collections, including Substance, Compound, BioAssay, Protein, Gene, Pathway, and Patent. These collections are interlinked with each other, allowing users to discover related records in the various collections (e.g., drugs targeting a protein or genes modulated by a chemical). PubChem can be searched by keyword (e.g., a chemical, protein, or gene name) as well as by chemical structure. The input structure can be provided using popular line notations or drawn with the PubChem Sketcher. PubChem supports various types of structure searches, including identity search, 2-D and 3-D similarity searches, and substructure and superstructure searches. Results from multiple searches can be combined using Boolean operators (i.e., AND, OR, and NOT) to formulate complex queries. PubChem allows the user to quickly retrieve a list of records annotated with a particular classification or ontological term. This paper provides step-by-step instructions on how to explore PubChem data with examples of commonly requested tasks. © 2021. This article is a U.S. Government work and is in the public domain in the USA. Current Protocols published by Wiley Periodicals LLC. Basic Protocol 1: Finding genes and proteins that interact with a given compound Basic Protocol 2: Finding drug-like compounds similar to a query compound through a two-dimensional (2-D) similarity search Basic Protocol 3: Finding compounds similar to a query compound through a three-dimensional (3-D) similarity search Support Protocol: Computing similarity scores between compounds Basic Protocol 4: Getting the bioactivity data for the hit compounds from substructure search Basic Protocol 5: Finding drugs that target a particular gene Basic Protocol 6: Getting bioactivity data of all chemicals tested against a protein. Basic Protocol 7: Finding compounds annotated with classifications or ontological terms Basic Protocol 8: Finding stereoisomers and isotopomers of a compound through identity search},
-	year = {2021}
+	year = {2021},
+	url = {https://doi.org/10.1002/cpz1.217},
 }
 
 @article{Kim2022,
+	author = {Sunghwan Kim and Tiejun Cheng and Siqian He and Paul A. Thiessen and Qingliang Li and Asta Gindulyte and Evan E. Bolton},
 	title = {PubChem Protein, Gene, Pathway, and Taxonomy Data Collections: Bridging Biology and Chemistry through Target-Centric Views of PubChem Data},
 	journal = {Journal of Molecular Biology},
 	volume = {434},
 	number = {11},
 	pages = {167514},
 	year = {2022},
-	note = {Computation Resources for Molecular Biology},
-	issn = {0022-2836},
-	doi = {https://doi.org/10.1016/j.jmb.2022.167514},
-	url = {https://www.sciencedirect.com/science/article/pii/S0022283622000882},
-	author = {Sunghwan Kim and Tiejun Cheng and Siqian He and Paul A. Thiessen and Qingliang Li and Asta Gindulyte and Evan E. Bolton},
-	keywords = {public chemical database, cheminformatics, bioinformatics, bioactivity, drug discovery},
-	abstract = {PubChem (https://pubchem.ncbi.nlm.nih.gov) is a public chemical database at the U.S. National Institutes of Health. Visited by millions of users every month, it plays a role as a key chemical information resource for biomedical research communities. Data in PubChem is from hundreds of contributors and organized into multiple collections by record type. Among these are the Protein, Gene, Pathway, and Taxonomy data collections. Records in these collections contain information on chemicals related to a given biological target (i.e., protein, gene, pathway, or taxon), helping users to analyze and interpret the biological activity data of molecules. In addition, annotations about the biological targets are collected from authoritative or curated data sources and integrated into the four collections. The content can be programmatically accessed through PubChem’s web service interfaces (including PUG View). A machine-readable representation of this content is also provided within PubChemRDF.}
+	url = {https://doi.org/10.1016/j.jmb.2022.167514},
 }
 
 @article{Kim2023,
@@ -74,12 +65,7 @@
     number = {D1},
     pages = {D1373-D1380},
     year = {2023},
-    month = {1},
-    abstract = "{PubChem (https://pubchem.ncbi.nlm.nih.gov) is a popular chemical information resource that serves a wide range of use cases. In the past two years, a number of changes were made to PubChem. Data from more than 120 data sources was added to PubChem. Some major highlights include: the integration of Google Patents data into PubChem, which greatly expanded the coverage of the PubChem Patent data collection; the creation of the Cell Line and Taxonomy data collections, which provide quick and easy access to chemical information for a given cell line and taxon, respectively; and the update of the bioassay data model. In addition, new functionalities were added to the PubChem programmatic access protocols, PUG-REST and PUG-View, including support for target-centric data download for a given protein, gene, pathway, cell line, and taxon and the addition of the ‘standardize’ option to PUG-REST, which returns the standardized form of an input chemical structure. A significant update was also made to PubChemRDF. The present paper provides an overview of these changes.}",
-    issn = {0305-1048},
-    doi = {https://doi.org/10.1093/nar/gkac956},
-    url = {https://doi.org/10.1093/nar/gkac956},
-    eprint = {https://academic.oup.com/nar/article-pdf/51/D1/D1373/48441598/gkac956.pdf},
+    url = {https://doi.org/10.1093/nar/gkac956}
 }
 
 @misc{NIST2022,

--- a/book/repositories/pubchem.md
+++ b/book/repositories/pubchem.md
@@ -56,6 +56,6 @@ This paper includes several protocols designed to help users to get familiar wit
 * **Basic Protocol 7**: [Finding compounds annotated with classifications or ontological terms](https://currentprotocols.onlinelibrary.wiley.com/doi/10.1002/cpz1.217#cpz1217-prot-0008)
 * **Basic Protocol 8**: [Finding stereoisomers and isotopomers of a compound through identity search](https://currentprotocols.onlinelibrary.wiley.com/doi/10.1002/cpz1.217#cpz1217-prot-0009)
 
-
 ```{bibliography}
+:filter: docname in docnames
 ```


### PR DESCRIPTION
Modified three files to fix the bibliography section.

(1) According to a Jupyter Book documentation page (https://jupyterbook.org/en/stable/content/citations.html), it is possible to add a reference section at the end of each page, by adding a filter to the bibliography directives:

```{bibliography}
:filter: docname in docnames
```

To test this behavior, I added this to the "pubchem.md" file.  And for comparison, I added the bibliography section (without the filter) to the "bibliography.md" file.

(2) I removed the DOI information from the papers in the "references.md" file.  The links to the papers will be shown as "URL: ......", not "DOI:.....".